### PR TITLE
Update us_metadata_loader.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@ Load the us legal case metadata from https://case.law/download/bulk_exports/late
 (U.S. Supreme Court Meta Data from Harvard Law Library of American Constitutional Reporters) - JSON (jsonl file)
 
 This was a question by KnowledgeShark on Libera:#mysql, and it was mildly interesting, so I coded that.
+
+----------------------------------------------------------------------------------------------------------------------
+
+Updated on my Fork (02.23.2022):
+
+I have updated the MariaDB Column Data Types so there are no errors while running the Python3 loader to parse .jsonl (JSON) to SQL (MariaDB) [MySQL Fork] | Create a MariaDB database; install the required Python 3 libraries; enter your correct MariaDB credentials for the newly created Database and run the Python3 script using the following command: "python3 us_metadata_loader.py" --- Depending on how much resources you have available depends on the amount of time it takes. 
+
+**There are approximately 1.8 Million Rows in this U.S. Constitutional Law MetaData for Jurisdiction: US/SCOTUS**
+
+**The full SQL File can be found here:** [https://archive.org/details/harvard.-cap.-meta-data.-jurisdiction.-us-02.21.2022](url) 
+
+**Special Thanks to Isotopp from Libera.Chat [IRC Network] #MySQL for making this possible in this way! His GitHub is found at:** [https://github.com/isotopp](url)
+
+**If you prefer to download the SQL file complete from archive.org; run the following command:**
+
+To import to MariaDB:
+
+`mysql -u username -p DATABASE_NAME < path/.sql` 
+
+Best Regards,
+
+Brandon Kastning
+TruthSword / KnowledgeShark
+Sharpen Your Sword 
+http://sharpenyoursword.org
+#JesusChristofNazareth #LetHISPeopleGo

--- a/us_metadata_loader.py
+++ b/us_metadata_loader.py
@@ -10,10 +10,10 @@ import MySQLdb.cursors
 
 ## Connection data configured here
 db_config = dict(
-    host="192.168.1.10",
-    user="kris",
-    password="geheim",
-    db="kris",
+    host="localhost",
+    user="username",
+    password="password",
+    db="Harvard_CAP_MetaData_Juris_US",
     cursorclass=MySQLdb.cursors.DictCursor,
 )
 db = MySQLdb.connect(**db_config)
@@ -26,7 +26,7 @@ sql_setup = [
       analysis_id integer not null auto_increment,
       cardinality integer not null,
       char_count integer not null,
-      ocr_confidence double not null,
+      ocr_confidence double null,
       pagerank_percentile double not null,
       pagerank_raw double not null,
       random_bucket integer not null,
@@ -50,7 +50,7 @@ sql_setup = [
     """create table citation (
         citation_id integer not null auto_increment,
         ct_id integer not null,
-        cite varchar(255) not null,
+        cite text null,
         primary key (citation_id)
     )""",
 
@@ -66,8 +66,8 @@ sql_setup = [
     """create table court (
         court_id integer not null auto_increment,
         name varchar(255) not null,
-        name_abbreviation varchar(64) not null,
-        slug varchar(64) not null,
+        name_abbreviation text null,
+        slug text not null,
         url varchar(255) not null,
         primary key (court_id)
     )""",
@@ -77,7 +77,7 @@ sql_setup = [
         jurisdiction_id integer not null,
         name varchar(64) not null,
         name_long varchar(255) not null,
-        slug varchar(64) not null,
+        slug text not null,
         url varchar(255) not null,
         whitelisted integer not null,
     
@@ -119,16 +119,16 @@ sql_setup = [
         -- citations as n:m relationship
         -- cites_to ignored
         court_id integer not null,
-        decision_date date not null,
+        decision_date text null,
         docket_number text not null,  -- varchar(255) too short
         first_page varchar(64) not null, -- "3-5"
-        frontend_pdf_url text not null, -- varchar(255) too short
+        frontend_pdf_url text null, -- varchar(255) too short
         frontend_url text not null, -- varchar(255) too short
         jurisdiction_id integer not null,
         last_page varchar(64) not null, -- "3-5"
-        last_updated datetime not null,
+        last_updated text null,
         name text not null, -- varchar(255) too short
-        name_abbreviation varchar(255) not null,
+        name_abbreviation text null,
         -- preview ignored
         
         provenance_id integer not null,


### PR DESCRIPTION
I have updated the MariaDB Column Data Types so there are no errors while running the Python3 loader to parse .jsonl (JSON) to SQL (MariaDB) [MySQL Fork] | Create a MariaDB database; install the required Python 3 libraries; enter your correct MariaDB credentials for the newly created Database and run the Python3 script using the following command: "python3 us_metadata_loader.py" --- Depending on how much resources you have available depends on the amount of time it takes. 

**There are approximately 1.8 Million Rows in this U.S. Constitutional Law MetaData for Jurisdiction: US/SCOTUS**

**The full SQL File can be found here:** [https://archive.org/details/harvard.-cap.-meta-data.-jurisdiction.-us-02.21.2022](url) 

**Special Thanks to Isotopp from Libera.Chat [IRC Network] #MySQL for making this possible in this way! His GitHub is found at:** [https://github.com/isotopp](url)

**If you prefer to download the SQL file complete from archive.org; run the following command:**

To import to MariaDB:

`mysql -u username -p DATABASE_NAME < path/.sql` 

Best Regards,

Brandon Kastning
TruthSword / KnowledgeShark
Sharpen Your Sword 
http://sharpenyoursword.org
#JesusChristofNazareth #LetHISPeopleGo
